### PR TITLE
Feature/modular -- latest stuff.

### DIFF
--- a/src/mms/bitvector.hpp
+++ b/src/mms/bitvector.hpp
@@ -16,8 +16,10 @@ namespace sdm {
 
       static constexpr std::size_t dimensions =  n_elements * sizeof(element_t) * CHAR_BITS;
       
-
-      // constructors
+      ///////////////////
+      /// constructors //
+      ///////////////////
+      
       bitvector() : base_t() {
         this->reserve(n_elements);
       }
@@ -26,10 +28,121 @@ namespace sdm {
         this->reserve(n_elements);
       }
 
-      
 
+      ////////////////////////////////
+      /// SDM bitvector arithmetic ///
+      ////////////////////////////////
+      
+      inline const std::size_t count() {
+        std::size_t count = 0;
+        for (unsigned i=0; i < n_elements; ++i) {
+          #if VELEMENT_64
+          count += __builtin_popcountll((*this)[i]);
+          #else
+          count += __builtin_popcount((*this)[i]);
+          #endif
+        }  
+        return count;
+      }
+
+      /// semantic density
+      
+      inline const double density() {
+        return (double) count() / dimensions;
+      }
+        
+      /////////////////////////////////////////// 
+      // semantic_vector measurement functions //
+      ///////////////////////////////////////////
+
+      /// semantic distance is the Hamming distance
+      
+      inline const std::size_t distance(const bitvector& v) {
+        std::size_t distance = 0;
+        #pragma unroll
+        #pragma clang loop vectorize(enable) interleave(enable)
+        for (unsigned i=0; i < n_elements; ++i) {
+          element_t r = (*this)[i] ^ v[i];
+          #ifdef VELEMENT_64
+          distance += __builtin_popcountll(r);
+          #else
+          distance += __builtin_popcount(r);
+          #endif
+        }
+        return distance;
+      }
     
-      // TODO: borrow entire implementation from symbol
+      /// inner product is the commonality/overlap
+      
+      inline const std::size_t inner(const bitvector& v) {
+        std::size_t count = 0;
+        #pragma unroll
+        #pragma clang loop vectorize(enable) interleave(enable)
+        for (unsigned i=0; i < n_elements; ++i) {
+          element_t r = (*this)[i] & v[i];
+          #ifdef VELEMENT_64
+          count += __builtin_popcountll(r);
+          #else
+          count += __builtin_popcount(r);
+          #endif
+        }
+        return count;
+      }
+      
+      /// semantic union
+      
+      inline std::size_t countsum(const bitvector& v) {
+        std::size_t count = 0;
+        #pragma unroll
+        #pragma clang loop vectorize(enable) interleave(enable)
+        for (unsigned i=0; i < n_elements; ++i) {
+          element_t r = (*this)[i] | v[i];
+          #ifdef VELEMENT_64
+          count += __builtin_popcountll(r);
+          #else
+          count += __builtin_popcount(r);
+          #endif
+        }
+        return count;
+      }
+    
+      /// semantic similarity
+      
+      inline double similarity(const bitvector& v) {
+        // inverse of the normalized distance
+        return 1.0 - (double) distance(v)/dimensions;
+      }
+    
+    
+      /// semantic overlap
+      
+      inline double overlap(const bitvector& v) {
+        // ratio of common bits to max common
+        return (double) inner(v)/dimensions;
+      }
+    
+    
+      /////////////////////////////////////////
+      /// in place transactions onbitvectors //
+      /////////////////////////////////////////
+    
+    
+      /* set all bits */
+    
+      inline void ones(void) {
+        for (unsigned i=0; i < n_elements; ++i) {
+          (*this)[i] = -1;
+        }
+      }
+    
+      /* clear all bits */
+    
+      inline void zeros(void) {
+        for (unsigned i=0; i < n_elements; ++i) {
+          (*this)[i] = 0;
+        }
+      }
+
     };
     
   }

--- a/src/mms/semantic_vector.hpp
+++ b/src/mms/semantic_vector.hpp
@@ -3,6 +3,8 @@
 #include <boost/interprocess/allocators/allocator.hpp>
 #include <boost/interprocess/containers/vector.hpp>
 #include "../rtl/sdmconfig.h"
+#include "bitvector.hpp"
+
 
 namespace sdm {
   namespace mms {
@@ -15,14 +17,25 @@ namespace sdm {
     template <typename segment_manager_t,
               typename element_t,
               unsigned n_elements>
+
     
     struct semantic_vector
-      : public bip::vector<element_t, bip::allocator<element_t, segment_manager_t>> {
+      : public bitvector<element_t,
+                         n_elements,
+                         bip::vector<element_t, bip::allocator<element_t, segment_manager_t>>,
+                         bip::allocator<void, segment_manager_t>> {
+      //: public bip::vector<element_t, bip::allocator<element_t, segment_manager_t>> {
 
       typedef typename bip::allocator<void, segment_manager_t> void_allocator_t;
       
-      typedef bip::vector<element_t, bip::allocator<element_t, segment_manager_t>> vector_base_t;
-            
+      // typedef bip::vector<element_t, bip::allocator<element_t, segment_manager_t>> vector_base_t;
+
+      typedef bitvector<element_t,
+                        n_elements,
+                        bip::vector<element_t, bip::allocator<element_t, segment_manager_t>>,
+                        bip::allocator<void, segment_manager_t>> vector_base_t;
+
+      
       /// construct fully
       semantic_vector(const void_allocator_t& a) : vector_base_t(a) {
         this->reserve(n_elements);

--- a/src/mms/symbol.hpp
+++ b/src/mms/symbol.hpp
@@ -6,11 +6,13 @@
 namespace sdm {
 
   namespace mms {
-  
-    ///
+    
+    //////////////////////////////////////////////////////////////////////
     /// symbol - named vector with lazily computed elemental fingerprint
-    ///
-
+    ///          and persistent storage for semantic vector this is the 
+    ///          learning and measurement abstraction
+    //////////////////////////////////////////////////////////////////////
+    
     template <typename segment_manager_t, typename shared_string_t, typename allocator_t>
   
     struct symbol final {
@@ -76,8 +78,10 @@ namespace sdm {
         return os;
       }
 
+      ///////////////////////////////////////////////////////
       /// SDM bitvector/semantic_vector delegated properties
-        
+      ///////////////////////////////////////////////////////
+      
       inline const std::size_t count() {
         return _vector.count();
       }

--- a/src/mms/symbol.hpp
+++ b/src/mms/symbol.hpp
@@ -79,21 +79,13 @@ namespace sdm {
       /// SDM bitvector/semantic_vector delegated properties
         
       inline const std::size_t count() {
-        std::size_t count = 0;
-        for (unsigned i=0; i < n_elements; ++i) {
-          #if VELEMENT_64
-          count += __builtin_popcountll(_vector[i]);
-          #else
-          count += __builtin_popcount(_vector[i]);
-          #endif
-        }  
-        return count;
+        return _vector.count();
       }
 
       /// semantic density
       
       inline const double density() {
-        return (double) count() / dimensions;
+        return _vector.density();
       }
         
       /////////////////////////////////////////// 
@@ -103,90 +95,33 @@ namespace sdm {
       /// semantic distance is the Hamming distance
       
       inline const std::size_t distance(const symbol& v) {
-        std::size_t distance = 0;
-        #pragma unroll
-        #pragma clang loop vectorize(enable) interleave(enable)
-        for (unsigned i=0; i < n_elements; ++i) {
-          element_t r = _vector[i] ^ v._vector[i];
-          #ifdef VELEMENT_64
-          distance += __builtin_popcountll(r);
-          #else
-          distance += __builtin_popcount(r);
-          #endif
-        }
-        return distance;
+        return _vector.distance(v._vector);
       }
     
       /// inner product is the commonality/overlap
       
       inline const std::size_t inner(const symbol& v) {
-        std::size_t count = 0;
-        #pragma unroll
-        #pragma clang loop vectorize(enable) interleave(enable)
-        for (unsigned i=0; i < n_elements; ++i) {
-          element_t r = _vector[i] & v._vector[i];
-          #ifdef VELEMENT_64
-          count += __builtin_popcountll(r);
-          #else
-          count += __builtin_popcount(r);
-          #endif
-        }
-        return count;
+        return _vector.distance(v._vector);
       }
       
       /// semantic union
       
       inline std::size_t countsum(const symbol& v) {
-        std::size_t count = 0;
-        #pragma unroll
-        #pragma clang loop vectorize(enable) interleave(enable)
-        for (unsigned i=0; i < n_elements; ++i) {
-          element_t r = _vector[i] | v._vector[i];
-          #ifdef VELEMENT_64
-          count += __builtin_popcountll(r);
-          #else
-          count += __builtin_popcount(r);
-          #endif
-        }
-        return count;
+        return _vector.countsum(v._vector);
       }
     
       /// semantic similarity
       
       inline double similarity(const symbol& v) {
-        // inverse of the normalized distance
-        return 1.0 - (double) distance(v)/dimensions;
+        return _vector.similarity(v._vector);
       }
-    
     
       /// semantic overlap
       
       inline double overlap(const symbol& v) {
-        // ratio of common bits to max common
-        return (double) inner(v)/dimensions;
+        return _vector.overlap(v._vector);
       }
     
-    
-      ////////////////////////////////////////////////
-      /// in place transactions on semantic vectors //
-      ////////////////////////////////////////////////
-    
-    
-      /* set all bits */
-    
-      inline void ones(void) {
-        for (unsigned i=0; i < n_elements; ++i) {
-          _vector[i] = -1;
-        }
-      }
-    
-      /* clear all bits */
-    
-      inline void zeros(void) {
-        for (unsigned i=0; i < n_elements; ++i) {
-          _vector[i] = 0;
-        }
-      }
 
       /////////////////////////
       /// learning utilities //

--- a/src/rtl/database.cpp
+++ b/src/rtl/database.cpp
@@ -67,12 +67,15 @@ namespace sdm {
   
   /// find symbols by prefix
   
-  boost::optional<database::symbol_list>
+  std::pair<status_t, database::symbol_list>
   database::prefix_search(const std::string& sn,
                           const std::string& vp) noexcept {
     auto sp = get_space_by_name(sn);
-    if (sp) return sp->search(vp);
-    else return boost::none;
+    if (sp) return std::make_pair(AOK, sp->search(vp));
+    else {
+      database::space::symbol_iterator a, b;
+      return std::make_pair(ESPACE, std::make_pair(a, b));
+    }
   }
   
   
@@ -281,11 +284,11 @@ namespace sdm {
 
   /// return cardinality of a space
     
-  boost::optional<std::size_t>
+  std::pair<status_t, std::size_t>
   database::get_space_cardinality(const std::string& sn) noexcept {
     auto sp = get_space_by_name(sn);
-    if (sp) return sp->entries();
-    else return boost::none;
+    if (sp) return std::make_pair(AOK, sp->entries());
+    else return std::make_pair(ESPACE, 0);
   }
   
   // XXX inline allocators refactoring 

--- a/src/rtl/database.hpp
+++ b/src/rtl/database.hpp
@@ -68,7 +68,7 @@ namespace sdm {
     typedef std::pair<database::space::symbol_iterator,
                       database::space::symbol_iterator> symbol_list;
     
-    boost::optional<symbol_list>
+    std::pair<status_t, symbol_list>
     prefix_search(const std::string& space_name,
                   const std::string& symbol_prefix) noexcept;
     
@@ -120,9 +120,9 @@ namespace sdm {
     
     
     
-    ////////////////////////
-    /// vector measurement
-    ////////////////////////
+    /////////////////////////
+    /// vector measurement //
+    /////////////////////////
     
     /// simlilarity (unit distance)
 
@@ -147,7 +147,7 @@ namespace sdm {
     std::vector<std::string>
     get_named_spaces() noexcept;
     
-    boost::optional<std::size_t>
+    std::pair<status_t, std::size_t>
     get_space_cardinality(const std::string&) noexcept;
 
     ///////////////////
@@ -176,7 +176,7 @@ namespace sdm {
                   const std::string&,
                   const space::symbol::type);
 
-    /// get space
+    /// get space max performance -- 
     //inline space* get_space_by_name(const std::string&) noexcept;     
     inline space* get_space_by_name(const std::string& name) noexcept {
       auto it = spaces.find(name);

--- a/src/rtl/manifold.cpp
+++ b/src/rtl/manifold.cpp
@@ -10,15 +10,19 @@ namespace sdm {
     : database::database(size, max, image, compact) {}
 
   
-  status_t manifold::get_topology(const std::string& space, topology_t& topo) {
+  status_t manifold::get_topology(const std::string& space, std::size_t n, topology_t& topo) {
     // step 1 get the space 
     database::space* sp = get_space_by_name(space);
     if (!sp) return ESPACE; // space not found
+
+    // just in case the caller asked for more than there is or indeed
+    // the world changed in the meantime.
+    
     std::size_t card = sp->entries();
     // allocate a topo which is just the vectors in the space
-    topo.reserve(card);
+    //topo.reserve(card);
     // now copy the symbols_spaces vectors from the space into caller
-    for (std::size_t i = 0; i < card; ++i) {
+    for (std::size_t i = 0; i < card && i < n; ++i) {
       auto s = sp->symbol_at(i);
       auto v = s.vector();
       vector_t b;

--- a/src/rtl/manifold.hpp
+++ b/src/rtl/manifold.hpp
@@ -24,8 +24,9 @@ namespace sdm {
                       const std::size_t max_size,
                       const std::string& filepath,
                       const bool compact=false);
-    
-    status_t get_topology(const std::string&, topology_t&); 
+
+    // get vectors for a space
+    status_t get_topology(const std::string&, std::size_t, topology_t&); 
     
   private:
     //database& _database;

--- a/src/test/frametrain.cpp
+++ b/src/test/frametrain.cpp
@@ -186,8 +186,10 @@ int main(int argc, const char** argv) {
     cout << "existing spaces in image:" << endl;
     // see if we can find space names
     std::vector<std::string> spaces = db.get_named_spaces();
+    
     for (auto sn: spaces) {
-      std::cout << sn << " #" << db.get_space_cardinality(sn) << std::endl;
+      auto ret = db.get_space_cardinality(sn);
+      std::cout << sn << " #" << ret.second << std::endl;
     }
   }
   
@@ -252,9 +254,18 @@ int main(int argc, const char** argv) {
   }
  
   // goodbye from me and goodbye from him...
-  cout << "at end of input rows: " << rows << " frames: " << frames << " empty frames: " << empty << endl;
-  if (cotrain) cout << termspace << " #" << db.get_space_cardinality(termspace) << endl;
-  if (reverse_index) cout << framespace << " #" << db.get_space_cardinality(framespace) << endl;
+  cout << "at end of input rows: " << rows
+       << " frames: " << frames
+       << " empty frames: " << empty << endl;
+  
+  if (cotrain) cout << termspace
+                    << " #"
+                    << db.get_space_cardinality(termspace).second << endl;
+
+  if (reverse_index) cout << framespace
+                          << " #"
+                          << db.get_space_cardinality(framespace).second << endl;
+  
   cout << (db.check_heap_sanity() ? ":-)" : ":-(") << " free: " << B2MB(db.free_heap()) << endl;
   
   return 0;

--- a/src/test/rtl_api.cpp
+++ b/src/test/rtl_api.cpp
@@ -59,11 +59,11 @@ BOOST_AUTO_TEST_CASE(rtl_api) {
   // get cardinality of space
   auto card = db.get_space_cardinality("names");
   
-  BOOST_REQUIRE(card);
-  BOOST_CHECK_EQUAL(*card, 6);
+  BOOST_REQUIRE(!sdm_error(card.first));
+  BOOST_CHECK_EQUAL(card.second, 6);
 
   manifold::topology_t t;
-  status_t sts = db.get_topology("names", t);
+  status_t sts = db.get_topology("names", card.second, t);
   BOOST_REQUIRE(!sdm_error(sts));
 
   BOOST_REQUIRE(t.size() == 6);

--- a/src/test/rtl_load_space.cpp
+++ b/src/test/rtl_load_space.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(rts_load_vectors) {
   
   std::string fline;
   int loaded = 0;
-  int onlyload = 100000;
+  int onlyload = 10000;
   
   while(std::getline(ins, fline) && loaded < onlyload) {
     boost::trim(fline);
@@ -59,14 +59,14 @@ BOOST_AUTO_TEST_CASE(rts_load_vectors) {
   // get cardinality of space
   auto card = rts.get_space_cardinality(test_space1);
   
-  BOOST_REQUIRE(card);
-  BOOST_CHECK_EQUAL(*card, loaded);
+  BOOST_REQUIRE(!sdm_error(card.first));
+  BOOST_CHECK_EQUAL(card.second, loaded);
   
   BOOST_TEST_MESSAGE("loaded: " << loaded << " will now prefix search (all)");
   
   // lookup all vectors
   auto sit = rts.prefix_search(test_space1, "");
-  if (sit) for (auto it = sit->first; it != sit->second; ++it) {
+  if (!sdm_error(sit.first)) for (auto it = sit.second.first; it != sit.second.second; ++it) {
     //std::cout << *it << std::endl;
     loaded--;
   }
@@ -78,13 +78,13 @@ BOOST_AUTO_TEST_CASE(rts_load_vectors) {
 BOOST_AUTO_TEST_CASE(rts_search_empty_space) {
 
   auto card = rts.get_space_cardinality(test_space1);
-  if (card) BOOST_TEST_MESSAGE(test_space1 << " #" << *card);
+  if (!sdm_error(card.first)) BOOST_TEST_MESSAGE(test_space1 << " #" << card.second);
   else BOOST_TEST_MESSAGE("cardinality: " << test_space1 << " no space found!");
   
   int found = 0;
   // lookup all vectors
   auto sit = rts.prefix_search(test_space1, "");
-  if (sit) for (auto it = sit->first; it != sit->second; ++it) {
+  if (!sdm_error(sit.first)) for (auto it = sit.second.first; it != sit.second.second; ++it) {
     //std::cout << *it << std::endl;
     found++;
   }

--- a/src/test/sdmi.cpp
+++ b/src/test/sdmi.cpp
@@ -17,7 +17,7 @@
 #include <boost/optional.hpp>
 #include <boost/optional/optional_io.hpp>
 
-// we are really developing this
+// XXX 
 #include "../rtl/manifold.hpp"
 
 
@@ -162,7 +162,8 @@ int main(int argc, const char** argv) {
   // see if we can find space names
   std::vector<std::string> spaces = rts.get_named_spaces();
   for (auto sn: spaces) {
-    std::cout << sn << " #" << rts.get_space_cardinality(sn) << std::endl;
+    auto card = rts.get_space_cardinality(sn);
+    std::cout << sn << " #" << card.second << std::endl;
   }
   
   // main command loop
@@ -230,7 +231,22 @@ int main(int argc, const char** argv) {
 
         
       } else if (boost::iequals(cv[0], ">")) {
-        ; // TODO NEXT dump vectors for a space or symbol
+
+        // XX under development
+        manifold::topology_t topo;
+        auto r = rts.get_space_cardinality(cv[1]);
+        
+        if (!sdm_error(r.first)) {
+          topo.reserve(r.second);
+          timer t;
+          status_t sts = rts.get_topology(cv[1], r.second, topo);
+          std::cout << t << "(" << sts << ")" << topo.size() << "/" << r.second << std::endl;
+          // TODO NEXT dump vectors to a file or matrix 
+
+        } else {
+          std::cout << "error: " << r.first << " for space: " << cv[1] << std::endl;
+        }
+
       
         
       } else if (boost::iequals(cv[0], "-")) {
@@ -308,9 +324,11 @@ int main(int argc, const char** argv) {
       if (parse_symbol(cv[0], default_space, sym)) {
           timer t;
           auto ip = rts.prefix_search(sym.front(), sym.back());
+          
           std::cout << t << std::endl;
-          if (ip) std::copy((*ip).first, (*ip).second,
-                            std::ostream_iterator<database::space::symbol>(std::cout, "\n"));
+          if (!sdm_error(ip.first))
+            std::copy(ip.second.first, ip.second.second,
+                      std::ostream_iterator<database::space::symbol>(std::cout, "\n"));
           else std::cout << sym.front() << ":" << sym.back() << " not found" << std::endl;
         }
     }

--- a/src/test/sdmi.cpp
+++ b/src/test/sdmi.cpp
@@ -18,18 +18,17 @@
 #include <boost/optional/optional_io.hpp>
 
 // we are really developing this
-#include "../rtl/database.hpp"
-// and this temporary vectors
-//#include "../mms/ephemeral_vector.hpp"
+#include "../rtl/manifold.hpp"
 
 
-// wall clock timer
+// a wall clock timer with microsecond resolution
 
 class timer {
   
 public:
 
-  timer(const std::string& name) : name(name), start(clock_t::local_time()) {}
+  // set the start time at construction
+  timer() : start(clock_t::local_time()) {}
 
   const std::size_t get_elapsed_micros() {
     
@@ -38,6 +37,7 @@ public:
     return d.total_microseconds();
   }
 
+  // ostream printer
   friend std::ostream& operator<<(std::ostream& os, timer& t) {
     os << "[" << t.get_elapsed_micros() << "] ";
     return os;
@@ -49,7 +49,6 @@ private:
   typedef boost::date_time::microsec_clock<time_t> clock_t;
   typedef boost::posix_time::time_duration elapsed_t;
   
-  std::string name;
   time_t start;
 };
 
@@ -70,6 +69,33 @@ void tokenize_command(const std::string& s, std::vector<std::string>& o) {
   }
 }
 
+
+// hack tokenizer for symbols
+
+bool parse_symbol(const std::string& s,
+                  const std::string& prefix,
+                  std::list<std::string>& parsed) {
+  
+  typedef boost::char_separator<char> sep_t;
+  typedef boost::tokenizer<sep_t> toz_t; 
+
+  sep_t sep(":");
+  toz_t tok(s, sep);
+  
+  for(toz_t::iterator j = tok.begin(); j != tok.end(); ++j) {
+    std::string t(*j);
+    boost::trim(t);
+    parsed.push_back(t);
+  }
+  if (parsed.size() == 1) parsed.push_front(prefix);
+  if (parsed.size() == 2) return true;
+  else {
+    std::cout << "cannot parse symbol: " << s << std::endl;
+    return false;
+  }
+}
+  
+  
 // quck and dirty file existence check avoiding boost::system/filesystem libraries
 
 inline bool file_exists(const char *path) {
@@ -99,16 +125,20 @@ int main(int argc, const char** argv) {
   
   po::options_description desc("Allowed options");
   po::positional_options_description p;
-  p.add("heap", -1);
+  p.add("heapimage", -1);
 
+  std::string default_space;
+  
   desc.add_options()
     ("help", "SDM runtime test utility")
     ("heapsize", po::value<std::size_t>(&initial_size)->default_value(700),
      "initial size of heap in Mbytes")
     ("maxheap", po::value<std::size_t>(&maximum_size)->default_value(700),
      "maximum size of heap in Mbytes")
-    ("heap", po::value<std::string>(),
-     "heap image name (should be a valid path)");
+    ("heapimage", po::value<std::string>(),
+     "heap image name (should be a valid path)")
+    ("prefix", po::value<std::string>(&default_space)->default_value("words"),
+     "default space name for unqalified symbols");
   
   po::variables_map opts;
   po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), opts);
@@ -117,20 +147,18 @@ int main(int argc, const char** argv) {
   if (opts.count("help")) {
     std::cout << desc <<  std::endl;
     return 1;
-  } else if (!opts.count("heap")) {
-    std::cout << "heap image is required!" << std::endl;
+  } else if (!opts.count("heapimage")) {
+    std::cout << "heap image file is required!" << std::endl;
     return 3;
   }
 
-  std::string heapfile(opts["heap"].as<std::string>());
+  std::string heapfile(opts["heapimage"].as<std::string>());
 
   
-  // create database with requirement
-  database rts(initial_size * 1024 * 1024, maximum_size * 1024 * 1024, heapfile); 
+  // create space manifold - database+
+ 
+  manifold rts(initial_size * 1024 * 1024, maximum_size * 1024 * 1024, heapfile); 
 
-  // XXX pro tem default space XXX FIX ME!!!
-  const std::string default_spacename("words");
-  
   // see if we can find space names
   std::vector<std::string> spaces = rts.get_named_spaces();
   for (auto sn: spaces) {
@@ -139,10 +167,8 @@ int main(int argc, const char** argv) {
   
   // main command loop
 
-  // what should this interface be called really?
-  //database::space::ephemeral_vector_t local_vector;
   
-  std::string prompt("Ψ> ");
+  std::string prompt("-> ");
   std::string input;
   
   std::cout << prompt;  
@@ -156,19 +182,21 @@ int main(int argc, const char** argv) {
     tokenize_command(input, cv);
 
     if (cv.size() > 1) {  
-      // assume we have a command
+      // assume we have a command and at least one argument
       
       // dispatch command
+
       if (boost::iequals(cv[0], "=")) {
 
-        // 
-        status_t s = rts.namedvector(default_spacename, cv[1]);
+        std::list<std::string> sym;
+        
+        if (parse_symbol(cv[1], default_space, sym)) {
+          timer t;
+          status_t s = rts.namedvector(sym.front(), sym.back());
+          std::cout << t << sym.front() << ":" << sym.back() << " (" << s << ")" << std::endl;
+        }        
 
-        // now lookup the inserted symbol density just to be sure
-        auto maybe_density = rts.density(default_spacename, cv[1]);
-        std::cout << maybe_density.second << "/" << s << std::endl;
-        
-        
+
       } else if (boost::iequals(cv[0], "<")) {
         
         // load symbols from file
@@ -177,56 +205,114 @@ int main(int argc, const char** argv) {
         if (ins.good()) {
           std::string fline;
           int n = 0;
-          timer mytimer("load timer");
+          timer mytimer;
           
           while(std::getline(ins, fline)) {
             boost::trim(fline);
-            auto sts = rts.namedvector(default_spacename, fline);
-            if (sdm_error(sts)) {
-              std::cout << "stopped loading due to error: " << sts << std::endl;
-              break;
+            std::list<std::string> sym;
+            if (parse_symbol(fline, default_space, sym)) {
+              auto sts = rts.namedvector(default_space, fline);
+              if (sdm_error(sts)) {
+                std::cout << "stopped loading due to error: " << sts << std::endl;
+                break;
+              }
+              n++;
+            } else {
+
             }
-            n++;
           }
+          
           std::cout << mytimer << " loaded: " << n << std::endl; 
+
         } else {
           std::cout << "can't open: " << cv[1] << std::endl;
         }
+
         
       } else if (boost::iequals(cv[0], ">")) {
-        ; // export file
+        ; // TODO NEXT dump vectors for a space or symbol
       
         
       } else if (boost::iequals(cv[0], "-")) {
-        rts.subtract(default_spacename, cv[1], default_spacename, cv[2]);
-        std::cout << rts.density(default_spacename, cv[1]).second << std::endl;
-      
-      } else if (boost::iequals(cv[0], "^")) {
-        rts.superpose(default_spacename, cv[1], default_spacename, cv[2]);
-        std::cout << rts.density(default_spacename, cv[1]).second << std::endl;
 
+        std::list<std::string> sym1;
+        std::list<std::string> sym2;
+
+        if (parse_symbol(cv[1], default_space, sym1) &&
+            parse_symbol(cv[2], default_space, sym2)) {
+          timer t;
+          rts.subtract(sym1.front(), sym1.back(), sym2.front(), sym2.back());
+          std::cout << t << rts.density(sym1.front(), sym1.back()).second << std::endl;
+        }
+        
+      } else if (boost::iequals(cv[0], "^")) {
+
+        std::list<std::string> sym1;
+        std::list<std::string> sym2;
+
+        if (parse_symbol(cv[1], default_space, sym1) &&
+            parse_symbol(cv[2], default_space, sym2)) {
+        
+          timer t;
+          rts.superpose(sym1.front(), sym1.back(), sym2.front(), sym2.back());
+          std::cout << t << rts.density(sym1.front(), sym1.back()).second << std::endl;
+        }
+        
       } else if (boost::iequals(cv[0], "+")) {
-        rts.superpose(default_spacename, cv[1], default_spacename, cv[2], true);
-        std::cout << rts.density(default_spacename, cv[1]).second << std::endl;
+
+        std::list<std::string> sym1;
+        std::list<std::string> sym2;
+
+        if (parse_symbol(cv[1], default_space, sym1) &&
+            parse_symbol(cv[2], default_space, sym2)) {
+        
+          timer t;
+          rts.superpose(sym1.front(), sym1.back(), sym2.front(), sym2.back(), true);
+          std::cout << t << rts.density(sym1.front(), sym1.back()).second << std::endl;
+        }
         
       } else if (boost::iequals(cv[0], "?")) {
-        std::cout << rts.similarity(default_spacename, cv[1], default_spacename, cv[2]).second
-                  << std::endl;
 
+        std::list<std::string> sym1;
+        std::list<std::string> sym2;
+        
+        if (parse_symbol(cv[1], default_space, sym1) &&
+            parse_symbol(cv[2], default_space, sym2)) {
+
+          timer t;
+          std::cout << t << rts.similarity(sym1.front(), sym1.back(),
+                                           sym2.front(), sym2.back()).second
+                    << std::endl;
+        }
         
       } else if (boost::iequals(cv[0], ".")) {
-        std::cout << rts.overlap(default_spacename, cv[1], default_spacename, cv[2]).second
-                  << std::endl;
+          
+        std::list<std::string> sym1;
+        std::list<std::string> sym2;
         
-      } else
-        std::cout << "syntax error:" << input << std::endl;
+        if (parse_symbol(cv[1], default_space, sym1) &&
+            parse_symbol(cv[2], default_space, sym2)) {
+
+          timer t;
+          double o = rts.overlap(sym1.front(), sym1.back(), sym2.front(), sym2.back()).second;
+          std::cout << t << o << std::endl;
+        }
+        
+      } else std::cout << "! syntax error:" << input << std::endl;
 
       
     } else if (cv.size() > 0) {
       // default to search if no args
-      auto ip = rts.prefix_search(default_spacename, cv[0]);
-      if (ip) std::copy((*ip).first, (*ip).second, std::ostream_iterator<database::space::symbol>(std::cout, "\n"));
-      else std::cout << "not found" << std::endl;
+      std::list<std::string> sym;
+
+      if (parse_symbol(cv[0], default_space, sym)) {
+          timer t;
+          auto ip = rts.prefix_search(sym.front(), sym.back());
+          std::cout << t << std::endl;
+          if (ip) std::copy((*ip).first, (*ip).second,
+                            std::ostream_iterator<database::space::symbol>(std::cout, "\n"));
+          else std::cout << sym.front() << ":" << sym.back() << " not found" << std::endl;
+        }
     }
     
     std::cout << prompt;  

--- a/src/test/sdmi.cpp
+++ b/src/test/sdmi.cpp
@@ -186,8 +186,18 @@ int main(int argc, const char** argv) {
       // assume we have a command and at least one argument
       
       // dispatch command
+      if (boost::iequals(cv[0], "|")) {
 
-      if (boost::iequals(cv[0], "=")) {
+        std::list<std::string> sym;
+        
+        if (parse_symbol(cv[1], default_space, sym)) {
+          timer t;
+          auto r = rts.density(sym.front(), sym.back());
+          std::cout << t << r.second << " (" << r.first << ")" << std::endl;
+        }        
+
+        
+      } else if (boost::iequals(cv[0], "=")) {
 
         std::list<std::string> sym;
         


### PR DESCRIPTION
Some "about time too" re-factorings in this one. Mainly the template from hell (can't seem to get typedef aliasing to work in clang so its a bit verbose and repetitive for now) for bitvector.hpp does the job of unifying allocations via. boost interprocess memory mapped file segments (spaces in the database) and regular C++ heap (std::allocator) or whatever else might be useful in the future like a GPGPU or FPGA allocator for the vectors. Even if this experiment with DSM turns out to be less that groundbreaking then the C++ framework for persistent collections of vectors will be handy for implementations in other more types like R (doubles/floats) or Z/N/C whatever.  

Next steps to make sure API is nice an clean and consistent and C FFI friendly, complete unit tests for same and then redo C library bindings. Move swiftly on to reworking Haskell bindings. 