### PR TITLE
Reverted the eager allocation of all the elements of semantic vectors…

### DIFF
--- a/src/mms/bitvector.hpp
+++ b/src/mms/bitvector.hpp
@@ -21,11 +21,11 @@ namespace sdm {
       ///////////////////
       
       bitvector() : base_t() {
-        this->resize(n_elements);
+        this->reserve(n_elements);
       }
       
       explicit bitvector(const allocator& a) : base_t(a) {
-        this->resize(n_elements);
+        this->reserve(n_elements);
       }
 
       /*


### PR DESCRIPTION
… which with hindsight make no sense for what are essentially in the main sparse. Nice work in spotting this at the same time we are studing actual usage of the system. The message is measure, profile and test not try and second guess either the compiler or the data structures. Premature omtimization turns out to be evil once again.