### PR TITLE
Using mutable symbol reference offers substantial speed up when reference counting

### DIFF
--- a/src/rtl/database.cpp
+++ b/src/rtl/database.cpp
@@ -91,7 +91,7 @@ namespace sdm {
     
     // get source symbol
     // TODO: optionally generate a new version or shifted basis
-    // and otionally reference count 
+    // NB: using mutable symbol reference offers a subtantial speed up when reference counting.
     //boost::optional<const space::symbol&> s = ssp.second->get_symbol_by_name(sn, refcount);
     boost::optional<space::symbol&> s = ssp.second->get_mutable_symbol_by_name(sn, refcount);
 


### PR DESCRIPTION
Using mutable symbol reference offers substantial speed up when reference counting. Halves the time taken on a substantial workload with many references.